### PR TITLE
Windows: fix OpenGL function loading via wgl and opengl32 exports

### DIFF
--- a/Source/OpenTK/Platform/Windows/WglHelper.cs
+++ b/Source/OpenTK/Platform/Windows/WglHelper.cs
@@ -121,10 +121,9 @@ namespace OpenTK.Platform.Windows
 
         static bool IsValid(IntPtr address)
         {
-            // See https://www.opengl.org/wiki/Load_OpenGL_Functions
-            long a = address.ToInt64();
-            bool is_valid = (a < -1) || (a > 3);
-            return is_valid;
+            // See https://www.opengl.org/wiki/Load_OpenGL_Functions,
+            // This tests for a not NULL and not -1, 1, 2, and 3.
+            return (address.ToInt64() > 3);
         }
 
         #endregion


### PR DESCRIPTION
`IsValid` did not test for all possible failure codes that `wglGetProcAddress` may return, specifically the NULL pointer. 
If `wglGetProcAddress` returns NULL and thus `Wgl.GetProcAddress(function_string)` returns `IntPtr.Zero`, `IsValid` actually returns true and OpenTK tries to load the requested function from 0x0, resulting in an AccessViolationException.

This fix changes the `IsValid` method to account for that, specifically implementing the recommended error handling as described in [0]:
## "While the MSDN documentation says that `wglGetProcAddress`​ returns NULL on failure, some implementations will return other values. 1, 2, and 3 are used, as well as -1."

[0] https://www.opengl.org/wiki/Load_OpenGL_Functions
